### PR TITLE
Added -monitoring.metrics-offset flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If you are still using the legacy [Access scopes][access-scopes], the `https://w
 | `google.project-id`<br />`STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID` | Yes | | Google Project ID |
 | `monitoring.metrics-type-prefixes`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES` | Yes | | Comma separated Google Stackdriver Monitoring Metric Type prefixes (see [example][metrics-prefix-example] and [available metrics][metrics-list]) |
 | `monitoring.metrics-interval`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL` | No | `5m` | Metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API. Only the most recent data point is used |
+| `monitoring.metrics-offset`<br />`STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET` | No | `0s` | Offset (into the past) for the metric's timestamp interval to request from the Google Stackdriver Monitoring Metrics API, to handle latency in published metrics |
 | `web.listen-address`<br />`STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS` | No | `:9255` | Address to listen on for web interface and telemetry |
 | `web.telemetry-path`<br />`STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH` | No | `/metrics` | Path under which to expose Prometheus metrics |
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -19,6 +19,7 @@ type MonitoringCollector struct {
 	projectID                       string
 	metricsTypePrefixes             []string
 	metricsInterval                 time.Duration
+	metricsOffset                   time.Duration
 	monitoringService               *monitoring.Service
 	apiCallsTotalMetric             prometheus.Counter
 	scrapesTotalMetric              prometheus.Counter
@@ -32,6 +33,7 @@ func NewMonitoringCollector(
 	projectID string,
 	metricsTypePrefixes []string,
 	metricsInterval time.Duration,
+	metricsOffset time.Duration,
 	monitoringService *monitoring.Service,
 ) (*MonitoringCollector, error) {
 	apiCallsTotalMetric := prometheus.NewCounter(
@@ -98,6 +100,7 @@ func NewMonitoringCollector(
 		projectID:                       projectID,
 		metricsTypePrefixes:             metricsTypePrefixes,
 		metricsInterval:                 metricsInterval,
+		metricsOffset:                   metricsOffset,
 		monitoringService:               monitoringService,
 		apiCallsTotalMetric:             apiCallsTotalMetric,
 		scrapesTotalMetric:              scrapesTotalMetric,
@@ -153,8 +156,8 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 
 		errChannel := make(chan error, len(page.MetricDescriptors))
 
-		startTime := time.Now().UTC().Add(c.metricsInterval * -1)
-		endTime := time.Now().UTC()
+		startTime := time.Now().UTC().Add(c.metricsInterval * -1).Add(c.metricsOffset * -1)
+		endTime := time.Now().UTC().Add(c.metricsOffset * -1)
 
 		for _, metricDescriptor := range page.MetricDescriptors {
 			wg.Add(1)

--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -34,6 +34,11 @@ var (
 		"Interval to request the Google Stackdriver Monitoring Metrics for. Only the most recent data point is used ($STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL).",
 	)
 
+	monitoringMetricsOffset = flag.Duration(
+		"monitoring.metrics-offset", 0*time.Second,
+		"Offset for the Google Stackdriver Monitoring Metrics interval into the past ($STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET).",
+	)
+
 	listenAddress = flag.String(
 		"web.listen-address", ":9255",
 		"Address to listen on for web interface and telemetry ($STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS).",
@@ -58,6 +63,7 @@ func overrideFlagsWithEnvVars() {
 	overrideWithEnvVar("STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID", projectID)
 	overrideWithEnvVar("STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES", monitoringMetricsTypePrefixes)
 	overrideWithEnvDuration("STACKDRIVER_EXPORTER_MONITORING_METRICS_INTERVAL", monitoringMetricsInterval)
+	overrideWithEnvDuration("STACKDRIVER_EXPORTER_MONITORING_METRICS_OFFSET", monitoringMetricsOffset)
 	overrideWithEnvVar("STACKDRIVER_EXPORTER_WEB_LISTEN_ADDRESS", listenAddress)
 	overrideWithEnvVar("STACKDRIVER_EXPORTER_WEB_TELEMETRY_PATH", metricsPath)
 }
@@ -125,7 +131,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	monitoringCollector, err := collectors.NewMonitoringCollector(*projectID, metricsTypePrefixes, *monitoringMetricsInterval, monitoringService)
+	monitoringCollector, err := collectors.NewMonitoringCollector(*projectID, metricsTypePrefixes, *monitoringMetricsInterval, *monitoringMetricsOffset, monitoringService)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)


### PR DESCRIPTION
This allows offsetting the metrics interval into the past. This is useful to e.g. fetch 1 minutes worth of metrics from 3 minutes ago, to avoid double-counting and latency issues. See #12 for details.