### PR TITLE
Switch DELTA to gauge from counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Metrics gathered from Google Stackdriver Monitoring are converted to Prometheus 
   3. the metric type labels (see [Metrics List][metrics-list])
   4. the monitored resource labels (see [Monitored Resource Types][monitored-resources])
 * For each timeseries, only the most recent data point is exported.
-* Stackdriver `GAUGE` metric kinds are reported as Prometheus `Gauge` metrics; Stackdriver `DELTA` and `CUMULATIVE` metric kinds are reported as Prometheus `Counter` metrics.
+* Stackdriver `GAUGE` and `DELTA` metric kinds are reported as Prometheus `Gauge` metrics; Stackdriver `CUMULATIVE` metric kinds are reported as Prometheus `Counter` metrics.
 * Only `BOOL`, `INT64`, `DOUBLE` and `DISTRIBUTION` metric types are supported, other types (`STRING` and `MONEY`) are discarded.
 * `DISTRIBUTION` metric type is reported as a Prometheus `Histogram`, except the `_sum` time series is not supported.
 

--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -278,7 +278,7 @@ func (c *MonitoringCollector) reportTimeSeriesMetrics(
 		case "GAUGE":
 			metricValueType = prometheus.GaugeValue
 		case "DELTA":
-			metricValueType = prometheus.CounterValue
+			metricValueType = prometheus.GaugeValue
 		case "CUMULATIVE":
 			metricValueType = prometheus.CounterValue
 		default:


### PR DESCRIPTION
A Counter is defined as a cumulative metric that only ever goes up. The DELTA value could go up or down depending on the minute of time and what is measured.

Tested this on our live instance and switching this without changing the name doesn't seem to break anything in Prometheus.