### PR TITLE
Align starttime and endtime to be based on the same time.Now() call

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -156,8 +156,8 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 
 		errChannel := make(chan error, len(page.MetricDescriptors))
 
-		startTime := time.Now().UTC().Add(c.metricsInterval * -1).Add(c.metricsOffset * -1)
 		endTime := time.Now().UTC().Add(c.metricsOffset * -1)
+		startTime := endTime.Add(c.metricsInterval * -1)
 
 		for _, metricDescriptor := range page.MetricDescriptors {
 			wg.Add(1)


### PR DESCRIPTION
It turns out that even a single nanosecond difference between starttime and endtime results in an additional block of timeseries data to be loaded.

As it was implemented, the `monitoring.metrics-interval` between starttime and endtime would be a tiny bit wider than requested.

It seems a minor thing, but it causes the API to return another block of data (another minute's worth of data).

When requesting data via the API monitoring, it uses the `endtime` as the starting point for the range of data to be returned (mandatory field). It then works its way backwards until it fulfils the provided `starttime` in the API call (optional field).

It only stops when the `starttime` of the block of data is of an earlier or equals date to the `starttime` specified in the API call. Remember that the data from the API comes in slots of 1 minutes.

Here is an working example for an internal of 2 minutes:
* starttime: 2018-03-12 11:43:00
* endtime:   2018-03-12 11:45:00.000001

The API would return available data for the last 3 slots:
* between 2018-03-12 11:44:00.000001 and 2018-03-12 11:45.000001
* between 2018-03-12 11:43:00.000001 and 2018-03-12 11:44.000001
* between 2018-03-12 11:42:00.000001 and 2018-03-12 11:43.000001

So, this change now ensures the starttime and endtime values are aligned.