### PR TITLE
Updates Dockerfile to build from the sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
-FROM        quay.io/prometheus/busybox:latest
-MAINTAINER  Ferran Rodenas <frodenas@gmail.com>
+###############################################################################
+# compile stage
+FROM golang:1.11
 
-COPY stackdriver_exporter /bin/stackdriver_exporter
+RUN mkdir -vp /go/src/github.com/frodenas/stackdriver_exporter/
+COPY . /go/src/github.com/frodenas/stackdriver_exporter
+# RUN go get -d github.com/frodenas/stackdriver_exporter
 
-ENTRYPOINT ["/bin/stackdriver_exporter"]
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/frodenas/stackdriver_exporter
+
+###############################################################################
+# binary stage
+FROM alpine
+
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=0 /go/bin/stackdriver_exporter       /root/stackdriver_exporter
+
+ENTRYPOINT ["/root/stackdriver_exporter"]
 EXPOSE     9255


### PR DESCRIPTION
This provides a new Dockerfile that to the build from the source and a lightweight second stage with only the binary, resulting a 16.9Mb image.

```
REPOSITORY                   TAG                 IMAGE ID            CREATED             SIZE
prom_sdexporter              latest              df4f42ce3adb        13 minutes ago      16.9MB
```
