### PR TITLE
Add option to drop metrics from delegated projects

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -23,6 +23,10 @@ var (
 		"google.project-id", "Google Project ID ($STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID).",
 	).Envar("STACKDRIVER_EXPORTER_GOOGLE_PROJECT_ID").Required().String()
 
+	monitoringDropDelegatedProjects = kingpin.Flag(
+		"monitoring.drop-delegated-projects", "Drop metrics from attached projects and fetch `project_id` only ($STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS).",
+	).Envar("STACKDRIVER_EXPORTER_DROP_DELEGATED_PROJECTS").Default("false").Bool()
+
 	monitoringMetricsTypePrefixes = kingpin.Flag(
 		"monitoring.metrics-type-prefixes", "Comma separated Google Stackdriver Monitoring Metric Type prefixes ($STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES).",
 	).Envar("STACKDRIVER_EXPORTER_MONITORING_METRICS_TYPE_PREFIXES").Required().String()
@@ -124,7 +128,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	monitoringCollector, err := collectors.NewMonitoringCollector(*projectID, metricsTypePrefixes, *monitoringMetricsInterval, *monitoringMetricsOffset, monitoringService, *collectorFillMissingLabels)
+	monitoringCollector, err := collectors.NewMonitoringCollector(*projectID, metricsTypePrefixes, *monitoringMetricsInterval, *monitoringMetricsOffset, monitoringService, *collectorFillMissingLabels, *monitoringDropDelegatedProjects)
 	if err != nil {
 		log.Error(err)
 		os.Exit(1)


### PR DESCRIPTION
Stackdriver allows delegation of multiple projects to "main" one. This is very useful to create inter-project dashbords, but also it delegates all metrics to single project and could lead to big amounts of series. I've added optional flag `monitoring.drop-delegated-projects` which allows one to disable collection of these metrics. It's useful to split stackdriver-exporter instances per-project
and still be able to fetch metrics from main one.

Another option is to have empty main project only to delegate monitoring and not to fetch metrics from.