### PR TITLE
Fix segmentation fault on missing credentials

### DIFF
--- a/stackdriver_exporter.go
+++ b/stackdriver_exporter.go
@@ -76,6 +76,9 @@ func createMonitoringService() (*monitoring.Service, error) {
 	ctx := context.Background()
 
 	googleClient, err := google.DefaultClient(ctx, monitoring.MonitoringReadScope)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating Google client: %v", err)
+	}
 
 	googleClient.Timeout = *stackdriverHttpTimeout
 	googleClient.Transport = rehttp.NewTransport(
@@ -85,10 +88,6 @@ func createMonitoringService() (*monitoring.Service, error) {
 			rehttp.RetryStatuses(*stackdriverRetryStatuses...)), // Cloud support suggests retrying on 503 errors
 		rehttp.ExpJitterDelay(*stackdriverBackoffJitterBase, *stackdriverMaxBackoffDuration), // Set timeout to <10s as that is prom default timeout
 	)
-
-	if err != nil {
-		return nil, fmt.Errorf("Error creating Google client: %v", err)
-	}
 
 	monitoringService, err := monitoring.New(googleClient)
 	if err != nil {


### PR DESCRIPTION
If no credentials supplied stackdriver_exporter binary goes segfaulted:

```
# ./stackdriver_exporter --google.project-id aproject --monit
oring.metrics-type-prefixes container.googleapis.com --stackdriver.http-timeout=10s
INFO[0000] Starting stackdriver_exporter (version=0.5.1, branch=master, revision=c36707967ebec2fb8977a54003797e5148c24936)  source="stackdriver_exporter.go:122"
INFO[0000] Build context (go=go1.10.5, user=root@857d0832fe06, date=20181119-16:33:41)  source="stackdriver_exporter.go:123"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x7b5e47]

goroutine 1 [running]:
main.createMonitoringService(0xc420049f38, 0x2, 0x2)
	/go/src/github.com/frodenas/stackdriver_exporter/stackdriver_exporter.go:84 +0xa7
main.main()
	/go/src/github.com/frodenas/stackdriver_exporter/stackdriver_exporter.go:125 +0x24c
```

The problem was in using `googleClient` before checking if it's creation succeeded.