### PR TITLE
Ensure metrics are fetched once for each metric descriptor

### DIFF
--- a/collectors/monitoring_collector.go
+++ b/collectors/monitoring_collector.go
@@ -160,12 +160,26 @@ func (c *MonitoringCollector) reportMonitoringMetrics(ch chan<- prometheus.Metri
 
 		c.apiCallsTotalMetric.Inc()
 
-		errChannel := make(chan error, len(page.MetricDescriptors))
+		// It has been noticed that the same metric descriptor can be obtained from different GCP
+		// projects. When that happens, metrics are fetched twice and it provokes the error:
+		//     "collected metric xxx was collected before with the same name and label values"
+		//
+		// Metric descriptor project is irrelevant when it comes to fetch metrics, as they will be
+		// fetched from all the delegated projects filtering by metric type. Considering that, we
+		// can filter descriptors to keep just one per type.
+		//
+		// The following makes sure metric descriptors are unique to avoid fetching more than once
+		uniqueDescriptors := make(map[string]*monitoring.MetricDescriptor)
+		for _, descriptor := range page.MetricDescriptors {
+			uniqueDescriptors[descriptor.Type] = descriptor
+		}
+
+		errChannel := make(chan error, len(uniqueDescriptors))
 
 		endTime := time.Now().UTC().Add(c.metricsOffset * -1)
 		startTime := endTime.Add(c.metricsInterval * -1)
 
-		for _, metricDescriptor := range page.MetricDescriptors {
+		for _, metricDescriptor := range uniqueDescriptors {
 			wg.Add(1)
 			go func(metricDescriptor *monitoring.MetricDescriptor, ch chan<- prometheus.Metric) {
 				defer wg.Done()


### PR DESCRIPTION
Fixes #48 

The approach taken here is to deduplicate metric descriptors based on `descriptor.Type` field, so we fetch metrics from a specific descriptor only once.

Please, review whether this approach is correct or there is a better way of doing it.